### PR TITLE
Update setup-teslausb

### DIFF
--- a/windows_archive/setup-teslausb
+++ b/windows_archive/setup-teslausb
@@ -85,7 +85,7 @@ function check_archive_mountable () {
 
   if [ "$mount_failed" = true ]
   then
-    echo "STOP: The archive couldn't be mounted with CIFS version ${cifs_version}. Try specifying a lower number for the CIFS version like this: export cifs_version=2"
+    echo "STOP: The archive couldn't be mounted with CIFS version ${cifs_version}. Try specifying a lower number for the CIFS version like this: export cifs_version=2.0"
 	exit 1
   fi
   


### PR DESCRIPTION
Got the "mount error(95): Operation not supported" error when running setup-teslausb to mount a share on a server that does not support CIFS 3.0. Message to the user suggests this: "

`Try specifying a lower number for the CIFS version like this: export cifs_version=2
`
This actually doesn't work. Changing this to:

`Try specifying a lower number for the CIFS version like this: export cifs_version=2.0
`
This works and is more helpful to the user.